### PR TITLE
Fix getAGC and autostart

### DIFF
--- a/plugin/bitrate.py
+++ b/plugin/bitrate.py
@@ -87,8 +87,11 @@ class Bitrate():
 			if len(line):
 				self.datalines.append(line)
 		if len(self.datalines) >= 2:
-			self.vmin, self.vmax, self.vavg, self.vcur = self.datalines[0].split(' ')
-			self.amin, self.amax, self.aavg, self.acur = self.datalines[1].split(' ')
+			try:
+				self.vmin, self.vmax, self.vavg, self.vcur = self.datalines[0].split(' ')
+				self.amin, self.amax, self.aavg, self.acur = self.datalines[1].split(' ')
+			except:
+			    self.clearValues()
 			self.datalines = []
 			if self.refresh_func:
 				self.refresh_func()

--- a/plugin/plugin.py
+++ b/plugin/plugin.py
@@ -676,7 +676,8 @@ class ourOIDStore(bisectoidstore.BisectOIDStore):
 	def getAGC(self):
 		if self.session and self.session.nav and self.session.nav.getCurrentService():
 			feinfo = self.session.nav.getCurrentService().frontendInfo()
-			return feinfo.getFrontendInfo(iFrontendInformation.signalPower) * 100 / 65536
+			if feinfo:
+				return feinfo.getFrontendInfo(iFrontendInformation.signalPower) * 100 / 65536
 		return 0
 
 	def getSNR(self):
@@ -1003,6 +1004,7 @@ def startSNMPserver(session):
 def sessionstart(reason, session):
 	global global_session
 	global_session = session
+	autostartEntry(True)
 
 #===============================================================================
 # autostart


### PR DESCRIPTION
Fix AGC query exception if not tuned to a service -> return default (0)
Fix agent autostart (WHERE_NETWORKCONFIG_READ doesn't fire on boot for whatever reason, tested on OpenATV 6.4)
Handle exception if bitrate receives garbage data